### PR TITLE
ユーザーの課金状況をUserから分割

### DIFF
--- a/OngekiScoreLog/app/Console/Kernel.php
+++ b/OngekiScoreLog/app/Console/Kernel.php
@@ -34,6 +34,7 @@ class Kernel extends ConsoleKernel
         // 全ユーザーの月初課金情報初期化
         $schedule->call(function () {
             \App\UserInformation::ResetAllUserPaymentState();
+            \App\Facades\Slack::Info("<!here> すべてのユーザーの課金情報をリセットしました。");
         })->monthlyOn(1, '4:00');
     }
 

--- a/OngekiScoreLog/app/Console/Kernel.php
+++ b/OngekiScoreLog/app/Console/Kernel.php
@@ -5,7 +5,6 @@ namespace App\Console;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use App\ApplicationVersion;
-use App\User;
 use App\Console\Commands\Maintenance;
 
 class Kernel extends ConsoleKernel
@@ -34,7 +33,7 @@ class Kernel extends ConsoleKernel
 
         // 全ユーザーの月初課金情報初期化
         $schedule->call(function () {
-            (new User())->setRoleAllUser(0, 2);
+            \App\UserInformation::ResetAllUserPaymentState();
         })->monthlyOn(1, '4:00');
     }
 

--- a/OngekiScoreLog/app/Http/Controllers/ViewUserController.php
+++ b/OngekiScoreLog/app/Http/Controllers/ViewUserController.php
@@ -43,9 +43,9 @@ class ViewUserController extends Controller
         if($user->role == 7){
             $status[0]->badge .= '&nbsp;<span class="tag developer">ProjectPrimera Developer</span>';
         }
-        if($user->role >= 2){
+        if(\App\UserInformation::IsPremiumPlan($user->id)){
             $status[0]->badge .= '&nbsp;<span class="tag net-premium">OngekiNet Premium</span>';
-        }else if($user->role >= 1){
+        }else if(\App\UserInformation::IsStandardPlan($user->id)){
             $status[0]->badge .= '&nbsp;<span class="tag net-standard">OngekiNet Standard</span>';
         }
 
@@ -133,7 +133,7 @@ class ViewUserController extends Controller
 
         foreach ($score as $key => $value) {
             // レート値を表示していいユーザーなら取得 だめなら隠す
-            if($user->role >= 2){
+            if(\App\UserInformation::IsPremiumPlan($user->id)){
                 $score[$key]->ratingValue = sprintf("%.2f", OngekiUtility::RateValueFromTitle($score[$key]->title, $score[$key]->difficulty, $score[$key]->technical_high_score));
                 $score[$key]->ratingValueRaw = $score[$key]->ratingValue;
                 if(OngekiUtility::IsEstimatedRateValueFromTitle($score[$key]->title, $score[$key]->difficulty, $score[$key]->technical_high_score)){
@@ -142,7 +142,7 @@ class ViewUserController extends Controller
                     $score[$key]->ratingValue = "<i><span class='max-rating'>" . $score[$key]->ratingValue . "</span></i>";
                 }
             }else{
-                $score[$key]->ratingValue = "|||||||||"; 
+                $score[$key]->ratingValue = "|||||||||";
                 $score[$key]->ratingValueRaw = 0;
             }
 

--- a/OngekiScoreLog/app/Http/Controllers/ViewUserRatingController.php
+++ b/OngekiScoreLog/app/Http/Controllers/ViewUserRatingController.php
@@ -64,7 +64,7 @@ class ViewUserRatingController extends Controller
             $sidemark = "sidemark_mypage_rating";
         }
 
-        if($user->role < 2){
+        if(!\App\UserInformation::IsPremiumPlan($user->id)){
             return view("user_rating_error", compact('id', 'status', 'sidemark'));
         }
 

--- a/OngekiScoreLog/app/Http/Controllers/ViewUserTrophyController.php
+++ b/OngekiScoreLog/app/Http/Controllers/ViewUserTrophyController.php
@@ -31,9 +31,9 @@ class ViewUserTrophyController extends Controller
         if($user->role == 7){
             $status[0]->badge .= '&nbsp;<span class="tag developer">ProjectPrimera Developer</span>';
         }
-        if($user->role >= 2){
+        if(\App\UserInformation::IsPremiumPlan($user->id)){
             $status[0]->badge .= '&nbsp;<span class="tag net-premium">OngekiNet Premium</span>';
-        }else if($user->role >= 1){
+        }else if(\App\UserInformation::IsStandardPlan($user->id)){
             $status[0]->badge .= '&nbsp;<span class="tag net-standard">OngekiNet Standard</span>';
         }
 

--- a/OngekiScoreLog/app/Providers/AuthServiceProvider.php
+++ b/OngekiScoreLog/app/Providers/AuthServiceProvider.php
@@ -30,16 +30,16 @@ class AuthServiceProvider extends ServiceProvider
 
 
         /* Laravel Gate Setting
-         * 10: 
-         *  9: 
-         *  8: 
+         * 10:
+         *  9:
+         *  8:
          *  7: 管理者
-         *  6: 
-         *  5: 
-         *  4: 
-         *  3: 
-         *  2: Ongeki-Net プレミアムプランユーザー
-         *  1: Ongeki-Net スタンダードプランユーザー
+         *  6:
+         *  5:
+         *  4:
+         *  3:
+         *  2: (deprecated) Ongeki-Net プレミアムプランユーザー
+         *  1: (deprecated) Ongeki-Net スタンダードプランユーザー
          *  0: 一般ユーザー
          */
         Gate::define('admin', function ($user) {

--- a/OngekiScoreLog/app/UserInformation.php
+++ b/OngekiScoreLog/app/UserInformation.php
@@ -8,10 +8,18 @@ class UserInformation extends Model{
     protected $table = "user_informations";
     protected $guarded = ['id'];
 
+    public static function ResetAllUserPaymentState(){
+        $all = self::all();
+        foreach ($all as $value) {
+            $value->update(['is_standard_plan' => 0, 'is_premium_plan' => 0]);
+        }
+    }
+
     public static function IsStandardPlan($userId){
         $u = self::where('user_id', $userId)->first();
         return ($u !== null && $u->is_standard_plan !== 0);
     }
+
     public static function IsPremiumPlan($userId){
         $u = self::where('user_id', $userId)->first();
         return ($u !== null && $u->is_premium_plan !== 0);

--- a/OngekiScoreLog/app/UserInformation.php
+++ b/OngekiScoreLog/app/UserInformation.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserInformation extends Model{
+    protected $table = "user_informations";
+    protected $guarded = ['id'];
+
+    public static function isStandardPlan($userId){
+        $u = self::where('user_id', $userId)->first();
+        return ($u !== null && $u->is_standard_plan !== 0);
+    }
+    public static function isPremiumPlan($userId){
+        $u = self::where('user_id', $userId)->first();
+        return ($u !== null && $u->is_premium_plan !== 0);
+    }
+}

--- a/OngekiScoreLog/app/UserInformation.php
+++ b/OngekiScoreLog/app/UserInformation.php
@@ -8,11 +8,11 @@ class UserInformation extends Model{
     protected $table = "user_informations";
     protected $guarded = ['id'];
 
-    public static function isStandardPlan($userId){
+    public static function IsStandardPlan($userId){
         $u = self::where('user_id', $userId)->first();
         return ($u !== null && $u->is_standard_plan !== 0);
     }
-    public static function isPremiumPlan($userId){
+    public static function IsPremiumPlan($userId){
         $u = self::where('user_id', $userId)->first();
         return ($u !== null && $u->is_premium_plan !== 0);
     }

--- a/OngekiScoreLog/database/migrations/2020_02_24_234621_create_user_informations_table.php
+++ b/OngekiScoreLog/database/migrations/2020_02_24_234621_create_user_informations_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateUserInformationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('user_informations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer("user_id");
+            $table->tinyInteger('is_standard_plan')->default(0);
+            $table->tinyInteger('is_premium_plan')->default(0);
+            $table->string('unique_id');
+            $table->timestamps();
+        });
+
+        // 以前の課金情報を削除する
+        (new \App\User())->setRoleAllUser(0, 2);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('user_informations');
+    }
+}


### PR DESCRIPTION
このコードより、User.roleで判定することができなくなります。
既存の環境ではmigrate時、User.roleが2以下のユーザーは0に設定されます。