### PR TITLE
ユーザーの楽曲詳細ページで日付表記がおかしい不具合を修正

### DIFF
--- a/OngekiScoreLog/app/Http/Controllers/ViewUserMusicController.php
+++ b/OngekiScoreLog/app/Http/Controllers/ViewUserMusicController.php
@@ -45,14 +45,16 @@ class ViewUserMusicController extends Controller
         $isExist->normal = !is_null($musicData->normal_added_version);
         $isExist->lunatic = !is_null($musicData->lunatic_added_version); 
 
-        $score = ScoreData::join('music_datas','score_datas.song_id','=','music_datas.id')->where(['user_id' => $id,'song_id' => $music, 'difficulty' => $dif])->get();
-
+        $score = ScoreData::join('music_datas','score_datas.song_id','=','music_datas.id')
+            ->where(['user_id' => $id,'song_id' => $music, 'difficulty' => $dif])
+            ->select('score_datas.technical_high_score', 'score_datas.battle_high_score', 'score_datas.over_damage_high_score', 'score_datas.created_at')
+            ->get();
 
         $technical = [];
         $battle = [];
         $damage = [];
         $date = [];
-        
+
         $prev = new \stdClass();
         $prev->technical = 0;
         $prev->battle = 0;
@@ -62,7 +64,7 @@ class ViewUserMusicController extends Controller
             $technical[] = (int)($value->technical_high_score);
             $battle[] = (int)($value->battle_high_score);
             $damage[] = (float)$value->over_damage_high_score;
-            $date[] = date('n/j', strtotime($value->updated_at));
+            $date[] = date('y/n/j', strtotime($value->created_at));
 
             $value->differenceTechnical = $value->technical_high_score - $prev->technical;
             $value->differenceBattle = $value->battle_high_score - $prev->battle;

--- a/OngekiScoreLog/resources/views/user_music.blade.php
+++ b/OngekiScoreLog/resources/views/user_music.blade.php
@@ -88,7 +88,7 @@
                                 <td>+{{$item->differenceDamage}}%</td>
                             @endif
 
-                            <td>{{date("Y/m/d H:i", strtotime($item->updated_at))}}</td>
+                            <td>{{date("Y/m/d H:i", strtotime($item->created_at))}}</td>
                         </tr>
                     @endforeach
                 </tbody>


### PR DESCRIPTION
join時に楽曲側のcreated_atで上書きされている為発生する不具合でした。
![image](https://user-images.githubusercontent.com/11350340/76704535-ff686b80-671c-11ea-86b5-fd5275f82fed.png)
